### PR TITLE
commas not needed in pip install command

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -20,7 +20,7 @@ An easy way to obtain the above packages is by using Python package manager
 by using the following command
 
 ```bash
-$ pip install cython, numpy, scipy, matplotlib, jupyter
+$ pip install cython numpy scipy matplotlib jupyter
 ```
 
 To install QmeQ through pip run


### PR DESCRIPTION
Hi Gediminas,

I don't know if it depends on PIP version but commas are not accepted on the shell command line as they mean something different. Removing them will make the install command work.